### PR TITLE
[PGP-36] Show a readable message for HTTP 504

### DIFF
--- a/sdk/android-sdk/src/main/res/values-es/strings.xml
+++ b/sdk/android-sdk/src/main/res/values-es/strings.xml
@@ -2,10 +2,11 @@
 <resources>
     <string name="it_error">HTTP %1$d: %2$s</string>
     <string name="it_error_internal">Error del sistema: %s</string>
-    <string name="it_error_no_network">No está conectado a internet </string>
+    <string name="it_error_no_network">No está conectado a internet</string>
     <string name="it_error_403">No tiene acceso a esta función</string>
     <string name="it_error_404">Recurso no encontrado</string>
     <string name="it_error_500">Error interno del servidor</string>
+    <string name="it_error_504">No está conectado a internet</string>
     <string name="it_no_authenticated_user">No hay un usuario registrado en este momento</string>
     <string name="it_session_expired">Tu sesión ha expirado, inicia sesión de nuevo por favor</string>
     <string name="it_user_update_failed">No se ha podido actualizar su perfil</string>

--- a/sdk/android-sdk/src/main/res/values-fr/strings.xml
+++ b/sdk/android-sdk/src/main/res/values-fr/strings.xml
@@ -6,6 +6,7 @@
     <string name="it_error_403">Vous n\'avez pas accès à cette fonctionnalité</string>
     <string name="it_error_404">L\'élément demande n\'existe pas</string>
     <string name="it_error_500">Erreur interne du serveur</string>
+    <string name="it_error_504">Vous n\'êtes pas connecté à Internet</string>
     <string name="it_no_authenticated_user">Aucun utilisateur n\'est connecté</string>
     <string name="it_session_expired">Votre session a expiré, veuillez vous reconnecter</string>
     <string name="it_user_update_failed">Échec de la sauvegarde de votre profil</string>

--- a/sdk/android-sdk/src/main/res/values-nl/strings.xml
+++ b/sdk/android-sdk/src/main/res/values-nl/strings.xml
@@ -6,6 +6,7 @@
     <string name="it_error_403">U heeft geen toegang tot dit onderdeel</string>
     <string name="it_error_404">Pagina niet gevonden</string>
     <string name="it_error_500">Interne serverfout</string>
+    <string name="it_error_504">U heeft geen verbinding met Internet</string>
     <string name="it_no_authenticated_user">Er is geen gebruiker aangemeld op dit moment</string>
     <string name="it_session_expired">De sessie is verlopen, log  opnieuw in</string>
     <string name="it_user_update_failed">Uw profiel kon niet worden opgeslagen</string>

--- a/sdk/android-sdk/src/main/res/values/strings.xml
+++ b/sdk/android-sdk/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="it_error_403">You don\'t have access to this feature</string>
     <string name="it_error_404">Resource not found</string>
     <string name="it_error_500">Internal server error</string>
+    <string name="it_error_504">You are not connected to the Internet</string>
     <string name="it_no_authenticated_user">There is no authenticated user right now</string>
     <string name="it_session_expired">Your session expired, please log-in again</string>
     <string name="it_user_update_failed">Could not update your profile</string>


### PR DESCRIPTION
La classe `ITApiError` utilise les chaînes de caractères `it_error_xxx` pour afficher un message intelligible en cas d'erreur HTTP.

L'erreur 504 est retournée lorsque le téléphone n'a pas accès à Internet, et que l'appli demande d'accéder au cache alors qu'aucun cache n'est disponible.

Dans ce cas, on affichera simplement qu'il n'y a pas de connexion à Internet.
