### PR TITLE
[PGP-22] Allow one refresh token request at a time

### DIFF
--- a/sdk/android-sdk/src/main/java/eu/intent/sdk/auth/internal/Oauth.java
+++ b/sdk/android-sdk/src/main/java/eu/intent/sdk/auth/internal/Oauth.java
@@ -2,6 +2,7 @@ package eu.intent.sdk.auth.internal;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
@@ -90,22 +91,7 @@ public final class Oauth {
         mService.requestToken(GRANT_TYPE_CODE, code, getClientId(), getClientSecret()).enqueue(new retrofit2.Callback<Info>() {
             @Override
             public void onResponse(Call<Info> call, Response<Info> response) {
-                if (response.isSuccessful()) {
-                    Info body = response.body();
-                    saveToken(body.accessToken, body.refreshToken, body.expiresIn);
-                    if (callback != null) callback.onSuccess(body);
-                } else {
-                    String errMessage;
-                    try {
-                        errMessage = response.errorBody().string();
-                    } catch (IOException e) {
-                        errMessage = response.message();
-                    }
-                    Log.e(Oauth.class.getCanonicalName(), errMessage);
-                    if (callback != null)
-                        callback.onFailure(response.code(), errMessage);
-
-                }
+                saveAccessTokenFromResponse(response, callback);
             }
 
             @Override
@@ -126,20 +112,7 @@ public final class Oauth {
             mService.refreshToken(REFRESH_GRANT_TYPE, getRefreshToken(), getClientId(), getClientSecret()).enqueue(new retrofit2.Callback<Info>() {
                 @Override
                 public void onResponse(Call<Info> call, Response<Info> response) {
-                    if (response.isSuccessful()) {
-                        Info body = response.body();
-                        saveToken(body.accessToken, body.refreshToken, body.expiresIn);
-                        if (callback != null) callback.onSuccess(body);
-                    } else {
-                        try {
-                            Log.e(Oauth.class.getCanonicalName(), response.errorBody().string());
-                        } catch (IOException ignored) {
-                            Log.e(Oauth.class.getCanonicalName(), response.message());
-                        }
-                        logout();
-                        if (callback != null)
-                            callback.onFailure(response.code(), response.message());
-                    }
+                    saveAccessTokenFromResponse(response, callback);
                     mRefreshTokenSemaphore.release();
                 }
 
@@ -168,23 +141,40 @@ public final class Oauth {
         try {
             mRefreshTokenSemaphore.acquire();
             Response<Info> response = mService.refreshToken(REFRESH_GRANT_TYPE, getRefreshToken(), getClientId(), getClientSecret()).execute();
-            if (response.isSuccessful()) {
-                Info body = response.body();
-                saveToken(body.accessToken, body.refreshToken, body.expiresIn);
-                newAccessToken = body.accessToken;
-            } else {
-                try {
-                    Log.e(getClass().getCanonicalName(), response.errorBody().string());
-                } catch (IOException ignored) {
-                    Log.e(getClass().getCanonicalName(), response.message());
-                }
-                logout();
-            }
+            newAccessToken = saveAccessTokenFromResponse(response, null);
             mRefreshTokenSemaphore.release();
         } catch (InterruptedException ignored) {
             // The thread has been interrupted while waiting for refreshing the token, abort (this will return null).
         }
         return newAccessToken;
+    }
+
+    /**
+     * Parses and saves the access token from a response body. If the response is a failure, the tokens are cleared.
+     *
+     * @param response the Response sent back by the access or refresh token request
+     * @param callback a custom Callback if you need to forward the response body
+     * @return the access token parsed from the response body, or null if the response is a failure
+     */
+    @Nullable
+    private String saveAccessTokenFromResponse(@NonNull Response<Info> response, @Nullable Callback callback) {
+        String accessToken = null;
+        if (response.isSuccessful()) {
+            Info body = response.body();
+            accessToken = body.accessToken;
+            saveToken(body.accessToken, body.refreshToken, body.expiresIn);
+            if (callback != null) callback.onSuccess(body);
+        } else {
+            try {
+                Log.e(Oauth.class.getCanonicalName(), response.errorBody().string());
+            } catch (IOException ignored) {
+                Log.e(Oauth.class.getCanonicalName(), response.message());
+            }
+            logout();
+            if (callback != null)
+                callback.onFailure(response.code(), response.message());
+        }
+        return accessToken;
     }
 
     /**


### PR DESCRIPTION
# Problématique

Lorsqu'on "réveille" l'appli après un temps suffisamment long pour que l'access token ait expiré (typiquement, après plus d'une heure d'inactivité) :
- plusieurs appels à l'API peuvent se faire simultanément pour recharger l'écran,
- étant donné que l'access token est expiré, l'API renvoie une erreur 401 pour chacun de ces appels,
- un "intercepteur" intercepte chacune de ces erreurs 401 avant de les transmettre à l'appli, et refresh l'access token.
## Exemple :
1. `GET /appel1` &rarr; 401
2. `GET /appel2` &rarr; 401
3. `POST /oauth/token {mon_refresh_token}` (suite à l'appel 1)
4. `POST /oauth/token {mon_refresh_token}` (suite à l'appel 2)
5. Résultat du 1er POST &rarr; `200 {nouveau_refresh_token}`
6. Résultat du 2ème POST &rarr; **`400 {"refresh token expired"}`**
7. Appels suivants à l'API &rarr; **`401 {"access token expired"}`**

Le 2ème POST avait en paramètre `mon_refresh_token`, qui a été déprécié suite au 1er POST.
# Résolution

Pour éviter d'envoyer plusieurs requêtes de refresh token avec le même paramètre (qui devient déprécié dès le premier retour de l'API), un sémaphore a été ajouté (initialisé à 1 jeton). Une requête de refresh token ne peut être effectuée que si la requête précédente a été traitée (que ce soit un succès ou un échec).

_À noter_ : `Semaphore.acquire()` peut lever une `InterruptedException` si le thread est interrompu avant qu'un jeton ne soit libéré.
