### PR TITLE
[PGP-289] Use the creationDate in state instead of the receptionDate.

### DIFF
--- a/sdk/android-sdk/src/main/java/eu/intent/sdk/model/ITState.java
+++ b/sdk/android-sdk/src/main/java/eu/intent/sdk/model/ITState.java
@@ -58,9 +58,9 @@ public class ITState implements Parcelable {
     public long validityDuration;
     public long validityExpirationDate;
     /**
-     * When the state was created. Typically, data reception date
+     * When the state was created. Typically, data creation date
      */
-    @SerializedName("receptionDate")
+    @SerializedName("creationDate")
     public long creationTime;
 
     transient public ITStateParams params;


### PR DESCRIPTION
Les dates des événements affichées dans Proximité correspondent à la date de création de l'état et non à la date de réception (pose problème lorsqu'on re-joue l'historique des états).

Raison technique : les dates sont inversées côté back, `creationDate` correspond à la date de réception et `receptionDate` correspond à la date de création.
Côté front Web, on se base sur `creationDate` pour l'affichage des alertes.
![selfie-1](http://i.imgur.com/Nd2FbOk.gif)
