### PR TITLE
Device scan tags

### DIFF
--- a/sdk/android-sdk/src/main/java/eu/intent/sdk/api/ITGenericApi.java
+++ b/sdk/android-sdk/src/main/java/eu/intent/sdk/api/ITGenericApi.java
@@ -1,0 +1,33 @@
+package eu.intent.sdk.api;
+
+import eu.intent.sdk.api.internal.ProxyCallback;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.http.GET;
+import retrofit2.http.Url;
+
+/**
+ * A wrapper to call any API.
+ */
+
+public class ITGenericApi {
+    private Service mService;
+
+    public ITGenericApi() {
+        // The service URL will override the base URL
+        mService = new Retrofit.Builder().baseUrl("http://whatever").build().create(Service.class);
+    }
+
+    /**
+     * Gets the response of the given URL as String.
+     */
+    public void get(String url, ITApiCallback<ResponseBody> callback) {
+        mService.get(url).enqueue(new ProxyCallback<>(callback));
+    }
+
+    private interface Service {
+        @GET
+        Call<ResponseBody> get(@Url String url);
+    }
+}

--- a/tests/app/build.gradle
+++ b/tests/app/build.gradle
@@ -26,5 +26,6 @@ dependencies {
     androidTestCompile 'com.android.support:support-annotations:25.0.1'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile 'com.squareup.okhttp3:mockwebserver:3.3.1'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/tests/app/src/androidTest/java/eu/intent/sdktests/AllTests.java
+++ b/tests/app/src/androidTest/java/eu/intent/sdktests/AllTests.java
@@ -13,6 +13,7 @@ import org.junit.runners.Suite;
         ITDataTest.class,
         ITDeviceTypeTest.class,
         ITEquipmentTest.class,
+        ITGenericApiTest.class,
         ITGreenGestureTest.class,
         ITLocationTest.class,
         ITMessageTest.class,

--- a/tests/app/src/androidTest/java/eu/intent/sdktests/AllTests.java
+++ b/tests/app/src/androidTest/java/eu/intent/sdktests/AllTests.java
@@ -11,7 +11,7 @@ import org.junit.runners.Suite;
         ITContactTest.class,
         ITConversationTest.class,
         ITDataTest.class,
-        ITDeviceTest.class,
+        ITDeviceTypeTest.class,
         ITEquipmentTest.class,
         ITGreenGestureTest.class,
         ITLocationTest.class,

--- a/tests/app/src/androidTest/java/eu/intent/sdktests/ITDeviceTypeTest.java
+++ b/tests/app/src/androidTest/java/eu/intent/sdktests/ITDeviceTypeTest.java
@@ -9,15 +9,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 
 import eu.intent.sdk.api.ITRetrofitUtils;
 import eu.intent.sdk.model.ITDeviceType;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
-public class ITDeviceTest {
+public class ITDeviceTypeTest {
     @Test
     public void jsonToDeviceTypeList() {
         String json = TestUtils.readRawFile(InstrumentationRegistry.getContext(), eu.intent.sdktests.test.R.raw.device_types);
@@ -130,5 +134,136 @@ public class ITDeviceTest {
         assertEquals("beginIndex", deviceTypes.get(2).outputs.get(0).params.get(1).key);
         assertEquals("^[-+]?[0-9]*\\.?[0-9]+$", deviceTypes.get(1).outputs.get(0).params.get(0).pattern);
         assertEquals("^[-+]?[0-9]*\\.?[0-9]+$", deviceTypes.get(2).outputs.get(0).params.get(1).pattern);
+        assertNotNull(deviceTypes.get(0).scanTags);
+        assertTrue(deviceTypes.get(0).scanTags.isEmpty());
+        assertEquals(3, deviceTypes.get(5).scanTags.size());
+        assertEquals(ITDeviceType.ScanTag.TYPE_NFC, deviceTypes.get(5).scanTags.get(0).type);
+        assertEquals(ITDeviceType.ScanTag.TYPE_QRCODE, deviceTypes.get(5).scanTags.get(1).type);
+        assertEquals("unknown", deviceTypes.get(5).scanTags.get(2).type);
+        assertNull(deviceTypes.get(5).scanTags.get(0).decoder);
+        assertNotNull(deviceTypes.get(5).scanTags.get(1).decoder);
+        assertNotNull(deviceTypes.get(5).scanTags.get(2).decoder);
+        assertEquals(ITDeviceType.ScanTag.Decoder.TYPE_URL, deviceTypes.get(5).scanTags.get(1).decoder.type);
+        assertEquals("unknown", deviceTypes.get(5).scanTags.get(2).decoder.type);
+        assertEquals("http://fakeapi.org/qrcode/{content}", deviceTypes.get(5).scanTags.get(1).decoder.data);
+        assertNull(deviceTypes.get(5).scanTags.get(2).decoder.data);
+    }
+
+    @Test
+    public void testGetScanTagWithNullList() {
+        ITDeviceType deviceType = new ITDeviceType();
+        deviceType.scanTags = null;
+        assertNull(deviceType.getScanTag("whatever"));
+    }
+
+    @Test
+    public void testGetScanTagWithEmptyList() {
+        ITDeviceType deviceType = new ITDeviceType();
+        deviceType.scanTags = new ArrayList<>();
+        assertNull(deviceType.getScanTag("whatever"));
+    }
+
+    @Test
+    public void testGetScanTagWithNoMatchingType() {
+        ITDeviceType.ScanTag tag1 = new ITDeviceType.ScanTag();
+        ITDeviceType.ScanTag tag2 = new ITDeviceType.ScanTag();
+        tag1.type = "type1";
+        tag2.type = "type2";
+        ITDeviceType deviceType = new ITDeviceType();
+        deviceType.scanTags = new ArrayList<>();
+        deviceType.scanTags.add(tag1);
+        deviceType.scanTags.add(tag2);
+        assertNull(deviceType.getScanTag("type3"));
+    }
+
+    @Test
+    public void testGetScanTagWithMatchingType() {
+        ITDeviceType.ScanTag tag1 = new ITDeviceType.ScanTag();
+        ITDeviceType.ScanTag tag2 = new ITDeviceType.ScanTag();
+        tag1.type = "type1";
+        tag2.type = "type2";
+        ITDeviceType deviceType = new ITDeviceType();
+        deviceType.scanTags = new ArrayList<>();
+        deviceType.scanTags.add(tag1);
+        deviceType.scanTags.add(tag2);
+        assertEquals(tag2, deviceType.getScanTag("type2"));
+    }
+
+    @Test
+    public void testGetScanTagWithSeveralMatchingType() {
+        ITDeviceType.ScanTag tag1 = new ITDeviceType.ScanTag();
+        ITDeviceType.ScanTag tag2 = new ITDeviceType.ScanTag();
+        tag1.type = "type1";
+        tag2.type = "type1";
+        ITDeviceType deviceType = new ITDeviceType();
+        deviceType.scanTags = new ArrayList<>();
+        deviceType.scanTags.add(tag1);
+        deviceType.scanTags.add(tag2);
+        ITDeviceType.ScanTag result = deviceType.getScanTag("type1");
+        assertNotNull(result);
+        assertTrue(result.equals(tag1) || result.equals(tag2));
+    }
+
+    @Test
+    public void testScanTagGetDecodeUrlWithNullTagType() {
+        ITDeviceType.ScanTag.Decoder tagDecoder = new ITDeviceType.ScanTag.Decoder();
+        tagDecoder.type = null;
+        tagDecoder.data = "http://fakedecoder.org/{content}";
+        String decodeUrl = tagDecoder.getDecodeUrl("123");
+        assertEquals("", decodeUrl);
+    }
+
+    @Test
+    public void testScanTagGetDecodeUrlWithWrongTagType() {
+        ITDeviceType.ScanTag.Decoder tagDecoder = new ITDeviceType.ScanTag.Decoder();
+        tagDecoder.type = "wrong_type";
+        tagDecoder.data = "http://fakedecoder.org/{content}";
+        String decodeUrl = tagDecoder.getDecodeUrl("123");
+        assertEquals("", decodeUrl);
+    }
+
+    @Test
+    public void testScanTagGetDecodeUrlWithNullUrl() {
+        ITDeviceType.ScanTag.Decoder tagDecoder = new ITDeviceType.ScanTag.Decoder();
+        tagDecoder.type = ITDeviceType.ScanTag.Decoder.TYPE_URL;
+        tagDecoder.data = null;
+        String decodeUrl = tagDecoder.getDecodeUrl("123");
+        assertEquals("", decodeUrl);
+    }
+
+    @Test
+    public void testScanTagGetDecodeUrlWithEmptyUrl() {
+        ITDeviceType.ScanTag.Decoder tagDecoder = new ITDeviceType.ScanTag.Decoder();
+        tagDecoder.type = ITDeviceType.ScanTag.Decoder.TYPE_URL;
+        tagDecoder.data = "";
+        String decodeUrl = tagDecoder.getDecodeUrl("123");
+        assertEquals("", decodeUrl);
+    }
+
+    @Test
+    public void testScanTagGetDecodeUrlWithoutPlaceholder() {
+        ITDeviceType.ScanTag.Decoder tagDecoder = new ITDeviceType.ScanTag.Decoder();
+        tagDecoder.type = ITDeviceType.ScanTag.Decoder.TYPE_URL;
+        tagDecoder.data = "http://fakedecoder.org/{wrong_placeholder}";
+        String decodeUrl = tagDecoder.getDecodeUrl("123");
+        assertEquals("http://fakedecoder.org/{wrong_placeholder}", decodeUrl);
+    }
+
+    @Test
+    public void testScanTagGetDecodeUrlWithNullContent() {
+        ITDeviceType.ScanTag.Decoder tagDecoder = new ITDeviceType.ScanTag.Decoder();
+        tagDecoder.type = ITDeviceType.ScanTag.Decoder.TYPE_URL;
+        tagDecoder.data = "http://fakedecoder.org/{content}";
+        String decodeUrl = tagDecoder.getDecodeUrl(null);
+        assertEquals("http://fakedecoder.org/{content}", decodeUrl);
+    }
+
+    @Test
+    public void testScanTagGetDecodeUrlWithCorrectUrlAndContent() {
+        ITDeviceType.ScanTag.Decoder tagDecoder = new ITDeviceType.ScanTag.Decoder();
+        tagDecoder.type = ITDeviceType.ScanTag.Decoder.TYPE_URL;
+        tagDecoder.data = "http://fakedecoder.org/{content}";
+        String decodeUrl = tagDecoder.getDecodeUrl("123");
+        assertEquals("http://fakedecoder.org/123", decodeUrl);
     }
 }

--- a/tests/app/src/androidTest/java/eu/intent/sdktests/ITGenericApiTest.java
+++ b/tests/app/src/androidTest/java/eu/intent/sdktests/ITGenericApiTest.java
@@ -1,0 +1,64 @@
+package eu.intent.sdktests;
+
+import android.support.test.filters.LargeTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import eu.intent.sdk.api.ITApiCallback;
+import eu.intent.sdk.api.ITGenericApi;
+import okhttp3.HttpUrl;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.fail;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ITGenericApiTest {
+    @Test
+    public void testGetUnreachableUrl() {
+        new ITGenericApi().get("", new ITApiCallback<ResponseBody>() {
+            @Override
+            public void onSuccess(ResponseBody result) {
+                fail("The URL does not exist, this should fail");
+            }
+
+            @Override
+            public void onFailure(int httpCode, String message) {
+                assertEquals(-1, httpCode);
+            }
+        });
+    }
+
+    @Test
+    public void testGetReachableUrl() throws IOException {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody("Hello, world!"));
+        server.start();
+
+        HttpUrl url = server.url("/fakeapi");
+        new ITGenericApi().get(url.toString(), new ITApiCallback<ResponseBody>() {
+            @Override
+            public void onSuccess(ResponseBody result) {
+                try {
+                    assertEquals("Hello, world!", result.string());
+                } catch (IOException e) {
+                    fail("Fail to read response");
+                }
+            }
+
+            @Override
+            public void onFailure(int httpCode, String message) {
+                fail("Fail to get response");
+            }
+        });
+
+        server.shutdown();
+    }
+}

--- a/tests/app/src/androidTest/res/raw/device_types.json
+++ b/tests/app/src/androidTest/res/raw/device_types.json
@@ -406,6 +406,24 @@
     },
     "mustBeActivated": false,
     "mustBeConnected": false,
-    "fullLabel": "nkesigfox_airflowsensor"
+    "fullLabel": "nkesigfox_airflowsensor",
+    "scanTags": [
+      {
+        "type": "nfc"
+      },
+      {
+        "type": "qrcode",
+        "decoder": {
+          "type": "url",
+          "data": "http://fakeapi.org/qrcode/{content}"
+        }
+      },
+      {
+        "type": "unknown",
+        "decoder": {
+          "type": "unknown"
+        }
+      }
+    ]
   }
 ]

--- a/tests/app/src/main/AndroidManifest.xml
+++ b/tests/app/src/main/AndroidManifest.xml
@@ -1,13 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="eu.intent.sdktests">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
-
-    </application>
+        android:theme="@style/AppTheme"></application>
 
 </manifest>


### PR DESCRIPTION
Il y a deux parties dans cette PR, dans deux commits différents :

- Ajout des tags supportés par le device type
- Ajout d'un service générique pour accéder à des APIs tierces (il y en a besoin pour accéder à l'API Qowisio)